### PR TITLE
password escape

### DIFF
--- a/src/models/MysqlDumpManager.php
+++ b/src/models/MysqlDumpManager.php
@@ -27,7 +27,7 @@ class MysqlDumpManager extends BaseDumpManager
             '--host=' . $dbInfo['host'],
             '--port=' . $dbInfo['port'],
             '--user=' . $dbInfo['username'],
-            '--password=' . $dbInfo['password'],
+            '--password=' . "'" . $dbInfo['password'] . "'",
         ];
         if ($dumpOptions['schemaOnly']) {
             $arguments[] = '--no-data';


### PR DESCRIPTION
It failed when password contained special characters like below ; semicolon
asdasd*pasdap;asdsd

Dump failed.
Command - mysqldump --host=localhost --port=3306 --user=user_db --password=dsfgsdfgp;dfgdgfA 
Usage: mysqldump [OPTIONS] database [tables] OR mysqldump [OPTIONS] --databases [OPTIONS] DB1 [DB2 DB3...] OR mysqldump [OPTIONS] --all-databases [OPTIONS] For more options, use mysqldump --help Warning: Using a password on the command line interface can be insecure. sh: dfg: command not found