### PR TITLE
Enhanced detection of error in flysytem when storing backup file

### DIFF
--- a/src/commands/DumpController.php
+++ b/src/commands/DumpController.php
@@ -74,17 +74,28 @@ class DumpController extends Controller
             $process->setTimeout($this->getModule()->timeout);
             $process->run();
             if ($process->isSuccessful()) {
+				$uploadResult = true;
                 if ($this->storage) {
                     if (Yii::$app->has('backupStorage')) {
-                        $dumpText = fopen($dumpPath, 'r+');
-                        Yii::$app->backupStorage->writeStream(StringHelper::basename($dumpPath), $dumpText);
-                        fclose($dumpText);
+						Console::output('Opening: '.$dumpPath);
+						
+						$storage = Yii::createObject([
+							'class' => 'creocoder\flysystem\LocalFilesystem',
+							'path' => dirname($dumpPath),
+						]);
+                        //$dumpText = fopen($dumpPath, 'r+');
+                        $uploadResult = Yii::$app->backupStorage->writeStream(StringHelper::basename($dumpPath), $storage->readStream(StringHelper::basename($dumpPath)));
+                        //fclose($dumpText);
+						//Console::output(print_r($uploadResult, 1));
                     } else {
                         Console::output('Storage component is not configured.');
                     }
                 }
-                Console::output('Dump successfully created.');
+				if ($uploadResult !== false) {
+					Console::output('Dump successfully created.');
+				}
             } else {
+				//Console::output(print_r($process->getErrorOutput(), 1));
                 Console::output('Dump failed create.');
             }
         } else {


### PR DESCRIPTION
Some flysytem may not throw exception when error, but return false, like spatie/flysystem-dropbox which don't throw exception when 400 or 409 error. This caused the dump command to show successful message even the upload is failed.

Also, fclose statement caused and unexpected error:
 - fclose(): supplied resource is not a valid stream resource

hence, i updated it to use flysystem\LocalFilesystem to open the source backuped file.