### PR TITLE
fix: improve error messages. fixes #38

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -136,10 +136,10 @@ class Module extends BaseModule
             $this->path .= '/';
         }
         if (!is_dir($this->path)) {
-            throw new InvalidConfigException('Path is not directory');
+            throw new InvalidConfigException("Path is not a directory: $this->path");
         }
         if (!is_writable($this->path)) {
-            throw new InvalidConfigException('Path is not writable! Check chmod!');
+            throw new InvalidConfigException("Path is not writable: $this->path");
         }
         $this->fileList = FileHelper::findFiles($this->path, ['only' => ['*.sql', '*.gz']]);
 


### PR DESCRIPTION
This addresses the error message mentioned in issue #38 
In addition, this also mentions the path that is not a directory, which had a similar issue of not actually giving the user the info he needs to solve the problem.

Tested it out and it now produces error messages like this:

```sh
$ yii help
```

> **Error:** Path is not writable: /home/ubuntu/runtime/console/backups/
